### PR TITLE
Fix constexpr_assert with exceptions disabled

### DIFF
--- a/include/gba/bits/constexpr_assert.hpp
+++ b/include/gba/bits/constexpr_assert.hpp
@@ -6,7 +6,7 @@
 
 namespace gba::bits {
 
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 202306L
+#if defined(__cpp_constexpr) && __cpp_constexpr >= 202306L && defined(__cpp_exceptions)
     inline constexpr bool supports_constexpr_throw = true;
 #else
     inline constexpr bool supports_constexpr_throw = false;
@@ -15,7 +15,7 @@ namespace gba::bits {
     extern "C" [[noreturn]] void __assert_func(const char* file, int line, const char* func, const char* expr);
 
     [[noreturn]] consteval inline void constexpr_fail(const char* message) {
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 202306L
+#if defined(__cpp_constexpr) && __cpp_constexpr >= 202306L && defined(__cpp_exceptions)
         throw message;
 #else
         (void)message;


### PR DESCRIPTION
`-fno-exceptions` still fails, because there's no test if the exceptions are disabled or not:
```cpp
../stdgba/include/gba/bits/constexpr_assert.hpp: In function 'consteval void gba::bits::constexpr_fail(const char*)':
../stdgba/include/gba/bits/constexpr_assert.hpp:19:15: error: exception handling disabled, use '-fexceptions' to enable
   19 |         throw message;
      |               ^~~~~~~
```