### PR TITLE
Allow exclude only views for ECS

### DIFF
--- a/include/gba/bits/ecs/registry.hpp
+++ b/include/gba/bits/ecs/registry.hpp
@@ -311,10 +311,10 @@ namespace gba::ecs {
 
         template<typename... ViewCs, typename... ExcludeCs>
         class basic_view<detail::view_query<group<ViewCs...>, group<ExcludeCs...>>> {
-            static_assert(sizeof...(ViewCs) > 0, "view requires at least one component");
+            static_assert(sizeof...(ViewCs) > 0 || sizeof...(ExcludeCs) > 0, "view requires at least one component");
 
             /// Required mask: alive + all requested components.
-            static constexpr std::uint32_t required = (bit_of<ViewCs> | ...) | alive_bit;
+            static constexpr std::uint32_t required = (alive_bit | ... | bit_of<ViewCs>);
             /// Forbidden mask: excluded components must all be absent.
             static constexpr std::uint32_t forbidden = (0u | ... | bit_of<ExcludeCs>);
 


### PR DESCRIPTION
Currently, it is not allowed to create exclude-only views:
```cpp
../my_project/src/gm/ecs/sys/room_change.cpp:105:75:   required from here
  105 |                     actor_reg.view<gba::ecs::exclude<cpn::critter_states>>().each(
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
../stdgba/include/gba/bits/ecs/registry.hpp:320:45: error: static assertion failed: view requires at least one component
  320 |             static_assert(sizeof...(ViewCs) > 0, "view requires at least one component");
      |                           ~~~~~~~~~~~~~~~~~~^~~
  • the comparison reduces to '(0 > 0)'
```